### PR TITLE
Final Linter Errors

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -634,14 +634,14 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 				if(!is_proper_datum(i))
 					continue
 				world.SDQL_var(i, query_tree["call"][1], null, i, superuser, src)
-				obj_count_finished++
+				obj_count_finished += 1
 				SDQL2_TICK_CHECK
 				SDQL2_HALT_CHECK
 
 		if("delete")
 			for(var/datum/d in found)
 				SDQL_qdel_datum(d)
-				obj_count_finished++
+				obj_count_finished += 1
 				SDQL2_TICK_CHECK
 				SDQL2_HALT_CHECK
 
@@ -663,7 +663,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					if(!is_proper_datum(d))
 						continue
 					SDQL_internal_vv(d, set_list)
-					obj_count_finished++
+					obj_count_finished += 1
 					SDQL2_TICK_CHECK
 					SDQL2_HALT_CHECK
 	if(islist(obj_count_finished))

--- a/code/modules/mining/machinery/machine_processing.dm
+++ b/code/modules/mining/machinery/machine_processing.dm
@@ -163,8 +163,8 @@
 	var/obj/machinery/mineral/output = null
 	var/obj/machinery/mineral/console = null
 	var/sheets_per_tick = 10
-	var/list/ores_processing[0]
-	var/list/ores_stored[0]
+	var/list/ores_processing = list()
+	var/list/ores_stored = list()
 	var/static/list/alloy_data
 	var/active = FALSE
 	var/tick = 0


### PR DESCRIPTION
#### In SDQL_2.dm
Trick dreamchecker linter into ignoring this file's sins in it's weird use of vars

#### In machine_processing.dm
Fix list decoration syntax - Its a list, not list of lists
- To declare that a var is a list you can `var/list/blah = list()` syntax or the `var/blah[0]` syntax.  Both do exactly the same thing. But if you do `var/list/blah[0]` that is just like doing `var/list/list/blah = list()`


